### PR TITLE
fix compiler potential nullptr - extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,7 +229,7 @@ function hasPhantomErrors(fileUri: vscode.Uri): boolean {
         const errorCode = typeof diagnostic.code === 'string'
             ? diagnostic.code
             : typeof diagnostic.code === 'object' && diagnostic.code !== null
-                ? String(diagnostic.code.value)
+                ? String((diagnostic.code as { value?: string }).value ?? '')
                 : '';
         return (
             diagnostic.severity === vscode.DiagnosticSeverity.Error &&


### PR DESCRIPTION
Compiler complained about the non-existence of property value type never, this type-casting (assertion) should check for existence and replace it with blank if null.